### PR TITLE
Improve config.ini.php HTTP accessibility check

### DIFF
--- a/Diagnostic/URLCheck.php
+++ b/Diagnostic/URLCheck.php
@@ -90,10 +90,10 @@ class URLCheck implements Diagnostic
     {
         $relativeUrl = "config/config.ini.php";
         list($status, $headers, $data) = $this->makeHTTPReququest($relativeUrl);
-        if ($this->contains($data, "salt")) {
+        if ($status < 400 && $status > 499 && $this->contains($data, "salt")) {
             return $this->isPublicError($relativeUrl, true);
         }
-        if ($this->contains($data, ";")) {
+        if ($status < 400 && $status > 499 && $this->contains($data, ";")) {
             return new DiagnosticResultItem(
                 DiagnosticResult::STATUS_WARNING,
                 Piwik::translate("DiagnosticsExtended_URLCheckConfigIni", ["<code>$relativeUrl</code>"])


### PR DESCRIPTION
My custom 404 error page has a ";" in it and thus creates a false positive warning that the config.ini.php file gets executed as PHP.

404/403 error pages containing ";" or "salt" should not trigger an error or warning.
