### PR TITLE
Update matomo.js check

### DIFF
--- a/Diagnostic/MatomoJsCheck.php
+++ b/Diagnostic/MatomoJsCheck.php
@@ -68,8 +68,8 @@ class MatomoJsCheck implements Diagnostic
             if (
                 $status != 200
                 || strpos($data, "c80d50af7d3db9be66a4d0a86db0286e4fd33292") === false
-                || empty($headers["content-type"])
-                || empty($headers["content-encoding"])
+                || empty($headers["Content-Type"])
+                || empty($headers["Vary"])
             ) {
                 $result = new DiagnosticResult($this->label);
                 $result->addItem(new DiagnosticResultItem(
@@ -82,8 +82,8 @@ class MatomoJsCheck implements Diagnostic
                 return [$result];
             }
             $results = new DiagnosticResult($this->label);
-            $contentType = $headers["content-type"];
-            if ($contentType !== "application/javascript") {
+            $contentType = $headers["Content-Type"];
+            if (strpos($contentType, "application/javascript") !== 0) {
                 $results->addItem(new DiagnosticResultItem(
                     DiagnosticResult::STATUS_WARNING,
                     Piwik::translate("DiagnosticsExtended_MatomoJSCheckMIMEError",
@@ -91,8 +91,8 @@ class MatomoJsCheck implements Diagnostic
                 ));
 
             }
-            $contentEncoding = $headers["content-encoding"];
-            if ($contentEncoding === "gzip" || $contentEncoding === "br") {
+            $vary = strtolower($headers["Vary"]);
+            if (strpos($vary, 'accept-encoding') !== false) {
                 $results->addItem(new DiagnosticResultItem(
                     DiagnosticResult::STATUS_OK,
                     Piwik::translate("DiagnosticsExtended_MatomoJSCheckGzipped")


### PR DESCRIPTION
Only HTTP/2 server use lowercase HTTP headers. Use capitalised header names for HTTP/1 support. 
Matomo will make sure that the capitalised header names will work with HTTP/2, too. See 
https://github.com/matomo-org/matomo/blob/1aec00ff0affa727ef134e230b465091b97e6863/core/Http.php#L1014-L1043


Content Types like `application/javascript; charset=utf-8` should not trigger a warning.


Matomo's HTTP::sendHttpRequest does not send the required `Accept-Encoding` header. Standards compliant HTTP servers cannot send compressed output in this case. This change does the compression check by checking for the existence of the correct `Vary` header. Standards-compliant HTTP servers should send it when compression is possible.

Unfortunately this check does not actually checks for compressed output. Looks like for that it would require another HTTP library that actually supports compressed HTTP responses. With standards compliant HTTP server it should be a good enough check, tho.